### PR TITLE
Shared .gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,6 @@
+[fetch]
+    prune = true
+[pull]
+    rebase = true
+[alias]
+    l = log --all --oneline --decorate --graph


### PR DESCRIPTION
- Always `--prune` remote tracking branches already removed from remote
- Always `--rebase` on `pull` instead of `merge` by default
- Alias for `git log --all --decorate --oneline --graph`